### PR TITLE
Improved auto-completion : support utf-8 

### DIFF
--- a/worker/go_completer.js
+++ b/worker/go_completer.js
@@ -114,10 +114,14 @@ function getOffset(doc, pos) {
         if (i === pos.row)
             return result + pos.column;
         
-        result += new TextEncoder().encode(lines[i]).length + 1;
+        result += lengthInUtf8(lines[i]) + 1;
     }
 }
-
+function lengthInUtf8(str) {
+        var asciiLength = str.match(/[\u0000-\u007f]/g) ? str.match(/[\u0000-\u007f]/g).length : 0;
+        var multiByteLength = encodeURI(str.replace(/[\u0000-\u007f]/g)).match(/%/g) ? encodeURI(str.replace(/[\u0000-\u007f]/g, '')).match(/%/g).length : 0;
+        return asciiLength + multiByteLength;
+}
 handler.predictNextCompletion = function(doc, fullAst, pos, options, callback) {
     if (!options.matches.length) {
         // Normally we wouldn't complete here, maybe we can complete for the next char?

--- a/worker/go_completer.js
+++ b/worker/go_completer.js
@@ -114,7 +114,7 @@ function getOffset(doc, pos) {
         if (i === pos.row)
             return result + pos.column;
         
-        result += lines[i].length + 1;
+        result += new TextEncoder().encode(lines[i]).length + 1;
     }
 }
 


### PR DESCRIPTION
support utf-8
Even if there are Hangul or Chinese characters, the automatic completion function works.
example :

package main

import (
	"fmt"
)

func main() {
	fmt.Println("aaaa")
	//한글테스트    아아아아아아아아아
	//真的
     fmt.
}